### PR TITLE
Export ignore .github folder

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@
 /.scrutinizer.yml   export-ignore
 /tests              export-ignore
 /.editorconfig      export-ignore
+/.github            export-ignore
+/.php_cs.dist       export-ignore
+/.prettierrc        export-ignore


### PR DESCRIPTION
It only excludes the `vendor/larsklopstra/nebula/.github` folder when someone installs the package.

Also export-ignore to.

- `/.php_cs.dist`
- `/.prettierrc`