### PR TITLE
Updated docblock

### DIFF
--- a/src/Fields/SelectField.php
+++ b/src/Fields/SelectField.php
@@ -12,7 +12,7 @@ class SelectField extends NebulaField
      * Sets the select fields's options properties.
      *
      * @param array $options
-     * @return SelectField
+     * @return $this
      */
     public function options(array $options): self
     {


### PR DESCRIPTION
This pr changes the docblock for the `options` method in the `SelectField`. This should fix the intellisense issue.

You may even use `@return self`, however Laravel uses `@return $this` as a standard for it's docblocks. In general you are free to choose what you want to use.

Here is a bit more information about return types as they are described by *fig-standards*:
[https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#abnf](https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc.md#abnf)