### PR TITLE
Edit models that have route key names other than ID

### DIFF
--- a/resources/views/resources/index.blade.php
+++ b/resources/views/resources/index.blade.php
@@ -107,7 +107,7 @@
 
                                     @foreach ($resource->indexFields() as $field)
                                         <td class="p-4 text-sm border-t border-gray-200">
-                                            <a href="{{ route('nebula.resources.show', [$resource->name(), $item->id]) }}">
+                                            <a href="{{ route('nebula.resources.show', [$resource->name(), $item]) }}">
                                                 <x-dynamic-component :item="$item" :component="$field->getTableComponent()"
                                                     :field="$field" />
                                             </a>

--- a/src/NebulaServiceProvider.php
+++ b/src/NebulaServiceProvider.php
@@ -111,10 +111,11 @@ class NebulaServiceProvider extends ServiceProvider
     public function itemResolver(): void
     {
         Route::bind('item', function ($value) {
-            return request()
-                ->resource
-                ->model()::withoutGlobalScopes()
-                ->findOrFail($value);
+            $model = request()->resource->model();
+
+            return $model::withoutGlobalScopes()
+                ->where((new $model)->getRouteKeyName(), $value)
+                ->firstOrFail();
         });
     }
 }


### PR DESCRIPTION
If a models route key name is changed from ID to something different it's currently not possible to edit it in Nebula. This PR fixes that.