### PR TITLE
feature: custom pages / tools

### DIFF
--- a/config/nebula.php
+++ b/config/nebula.php
@@ -28,4 +28,8 @@ return [
         // new UserDashboard,
     ],
 
+    'pages' => [
+        // new CustomPage,
+    ],
+
 ];

--- a/resources/views/components/layouts/shell.blade.php
+++ b/resources/views/components/layouts/shell.blade.php
@@ -137,28 +137,28 @@
             </ul>
 
             @if ($pages = config('nebula.pages'))
-            <ul class="px-2 my-4 space-y-1">
+                <ul class="px-2 my-4 space-y-1">
 
-                <li>
-                    <p class="flex items-center h-8 px-2 text-xs font-medium text-gray-300 uppercase">
-                        {{ __('Pages') }}
-                    </p>
-                </li>
-
-                @foreach ($pages as $page)
                     <li>
-
-                        <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
-                            href="{{ route('nebula.pages.index', $page->slug()) }}">
-                            {{ svg("heroicon-o-{$page->icon()}", ['class' => 'w-5 h-5 mr-2 text-gray-400']) }}
-                            {{ $page->name() }}
-                        </a>
-
+                        <p class="flex items-center h-8 px-2 text-xs font-medium text-gray-300 uppercase">
+                            {{ __('Pages') }}
+                        </p>
                     </li>
-                @endforeach
 
-            </ul>
-        @endif
+                    @foreach ($pages as $page)
+                        <li>
+
+                            <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
+                                href="{{ route('nebula.pages.index', $page->slug()) }}">
+                                {{ svg("heroicon-o-{$page->icon()}", ['class' => 'w-5 h-5 mr-2 text-gray-400']) }}
+                                {{ $page->name() }}
+                            </a>
+
+                        </li>
+                    @endforeach
+
+                </ul>
+            @endif
 
         </aside>
 

--- a/resources/views/components/layouts/shell.blade.php
+++ b/resources/views/components/layouts/shell.blade.php
@@ -61,6 +61,28 @@
                     @endforeach
 
                 </ul>
+
+                @if($pages = config('nebula.pages'))
+                    <ul class="px-2 my-4 space-y-1">
+
+                        <li>
+                            <p class="flex items-center h-8 px-2 text-xs font-medium text-gray-300 uppercase">
+                                {{ __('Pages') }}
+                            </p>
+                        </li>
+
+                        @foreach ($pages as $page)
+                            <li>
+                                <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
+                                    href="{{ route('nebula.pages.index', $page->name()) }}">
+                                    {{ svg("heroicon-o-{$page->icon()}", ['class' => 'w-5 h-5 mr-2 text-gray-400']) }}
+                                    {{ $page->name() }}
+                                </a>
+                            </li>
+                        @endforeach
+
+                    </ul>
+                @endif
             </nav>
         </aside>
 
@@ -113,6 +135,30 @@
                 @endforeach
 
             </ul>
+
+            @if ($pages = config('nebula.pages'))
+            <ul class="px-2 my-4 space-y-1">
+
+                <li>
+                    <p class="flex items-center h-8 px-2 text-xs font-medium text-gray-300 uppercase">
+                        {{ __('Pages') }}
+                    </p>
+                </li>
+
+                @foreach ($pages as $page)
+                    <li>
+
+                        <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
+                            href="{{ route('nebula.pages.index', $page->name()) }}">
+                            {{ svg("heroicon-o-{$page->icon()}", ['class' => 'w-5 h-5 mr-2 text-gray-400']) }}
+                            {{ $page->pluralName() }}
+                        </a>
+
+                    </li>
+                @endforeach
+
+            </ul>
+        @endif
 
         </aside>
 

--- a/resources/views/components/layouts/shell.blade.php
+++ b/resources/views/components/layouts/shell.blade.php
@@ -149,9 +149,9 @@
                     <li>
 
                         <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
-                            href="{{ route('nebula.pages.index', $page->name()) }}">
+                            href="{{ route('nebula.pages.index', $page->slug()) }}">
                             {{ svg("heroicon-o-{$page->icon()}", ['class' => 'w-5 h-5 mr-2 text-gray-400']) }}
-                            {{ $page->pluralName() }}
+                            {{ $page->name() }}
                         </a>
 
                     </li>

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -1,0 +1,7 @@
+<x-nebula::layouts.shell :title="$page->singularName()">
+
+    <div class="mb-8 space-y-4">
+        {{ $page->display() }}
+    </div>
+
+</x-nebula::layouts.shell>

--- a/resources/views/pages/index.blade.php
+++ b/resources/views/pages/index.blade.php
@@ -1,4 +1,4 @@
-<x-nebula::layouts.shell :title="$page->singularName()">
+<x-nebula::layouts.shell :title="$page->name()">
 
     <div class="mb-8 space-y-4">
         {{ $page->display() }}

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Larsklopstra\Nebula\Http\Controllers\DashboardController;
+use Larsklopstra\Nebula\Http\Controllers\PageController;
 use Larsklopstra\Nebula\Http\Controllers\ResourceController;
 use Larsklopstra\Nebula\Http\Controllers\StartController;
 
@@ -23,3 +24,5 @@ Route::name('resources.')->prefix('/resources')->group(function () {
 
     Route::delete('/{resource}/{item}', [ResourceController::class, 'destroy'])->name('destroy');
 });
+
+Route::get('/page/{page}', [PageController::class, 'index'])->name('pages.index');

--- a/src/Console/Commands/MakePageCommand.php
+++ b/src/Console/Commands/MakePageCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Larsklopstra\Nebula\Console\Commands;
+
+use Illuminate\Console\GeneratorCommand;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Str;
+
+class MakePageCommand extends GeneratorCommand
+{
+    protected $name = 'nebula:page';
+
+    protected $description = 'Create a Nebula page';
+
+    protected $type = 'Nebula page';
+
+    public function handle()
+    {
+        parent::handle();
+
+        File::ensureDirectoryExists($this->viewPath('nebula/pages'));
+
+        File::put($this->viewPath("nebula/pages/{$this->viewName()}.blade.php"), '');
+    }
+
+    protected function buildClass($name)
+    {
+        return str_replace(
+            'dummy-view',
+            $this->viewName(),
+            parent::buildClass($name)
+        );
+    }
+
+    protected function getStub()
+    {
+        return __DIR__.'/stubs/page.stub';
+    }
+
+    protected function getDefaultNamespace($rootNamespace)
+    {
+        return $rootNamespace.'\Nebula\Pages';
+    }
+
+    protected function viewName()
+    {
+        return (string) Str::of($this->argument('name'))
+            ->replaceLast('Page', '')
+            ->kebab()
+            ->lower();
+    }
+}

--- a/src/Console/Commands/stubs/page.stub
+++ b/src/Console/Commands/stubs/page.stub
@@ -1,0 +1,18 @@
+<?php
+
+namespace DummyNamespace;
+
+use Larsklopstra\Nebula\Contracts\NebulaPage;
+
+class DummyClass extends NebulaPage
+{
+    public function icon()
+    {
+        return 'document';
+    }
+
+    public function render()
+    {
+        return view('nebula.pages.dummy-view');
+    }
+}

--- a/src/Contracts/NebulaPage.php
+++ b/src/Contracts/NebulaPage.php
@@ -9,7 +9,7 @@ use Illuminate\Support\Stringable;
 
 abstract class NebulaPage
 {
-    public Closure $canSeeCallback;
+    public $canSeeCallback;
 
     /**
      * Specifies which icon should be used.

--- a/src/Contracts/NebulaPage.php
+++ b/src/Contracts/NebulaPage.php
@@ -2,12 +2,15 @@
 
 namespace Larsklopstra\Nebula\Contracts;
 
+use Closure;
 use Exception;
 use Illuminate\Support\Str;
 use Illuminate\Support\Stringable;
 
 abstract class NebulaPage
 {
+    public Closure $canSeeCallback;
+
     /**
      * Specifies which icon should be used.
      *
@@ -42,7 +45,7 @@ abstract class NebulaPage
     /**
      * Outputs the page.
      *
-     * @return
+     * @return mixed
      */
     public function display()
     {
@@ -51,5 +54,18 @@ abstract class NebulaPage
         }
 
         return app()->call([$this, 'render']);
+    }
+
+    /**
+     * Determine whether or not the page can be accessed.
+     *
+     * @param  \Closure  $callback
+     * @return static
+     */
+    public function canSee(Closure $callback)
+    {
+        $this->canSeeCallback = $callback;
+
+        return $this;
     }
 }

--- a/src/Contracts/NebulaPage.php
+++ b/src/Contracts/NebulaPage.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Larsklopstra\Nebula\Contracts;
+
+use Exception;
+use Illuminate\Support\Str;
+use Illuminate\Support\Stringable;
+
+abstract class NebulaPage
+{
+    /**
+     * Specifies which icon should be used.
+     *
+     * @return string
+     */
+    public function icon()
+    {
+        return 'tag';
+    }
+
+    /**
+     * Returns the name of the page.
+     *
+     * @return Stringable
+     */
+    public function name()
+    {
+        return Str::of(class_basename($this))
+            ->replaceLast('Page', '')
+            ->kebab()
+            ->lower()
+            ->plural();
+    }
+
+    /**
+     * Returns the page singular name.
+     *
+     * @return Stringable
+     */
+    public function singularName()
+    {
+        return Str::of($this->name())
+            ->replace('-', '')
+            ->singular();
+    }
+
+    /**
+     * Returns the page its plural name.
+     *
+     * @return string
+     */
+    public function pluralName()
+    {
+        return Str::plural($this->singularName());
+    }
+
+    /**
+     * Outputs the page.
+     *
+     * @return
+     */
+    public function display()
+    {
+        if (! method_exists($this, 'render')) {
+            throw new Exception('No `render` method defined on '.get_class($this));
+        }
+
+        return app()->call([$this, 'render']);
+    }
+}

--- a/src/Contracts/NebulaPage.php
+++ b/src/Contracts/NebulaPage.php
@@ -26,32 +26,17 @@ abstract class NebulaPage
     public function name()
     {
         return Str::of(class_basename($this))
-            ->replaceLast('Page', '')
-            ->kebab()
-            ->lower()
-            ->plural();
+            ->replaceLast('Page', '');
     }
 
     /**
-     * Returns the page singular name.
+     * Returns the slug of the page.
      *
      * @return Stringable
      */
-    public function singularName()
+    public function slug()
     {
-        return Str::of($this->name())
-            ->replace('-', '')
-            ->singular();
-    }
-
-    /**
-     * Returns the page its plural name.
-     *
-     * @return string
-     */
-    public function pluralName()
-    {
-        return Str::plural($this->singularName());
+        return $this->name()->kebab()->lower();
     }
 
     /**

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Larsklopstra\Nebula\Http\Controllers;
+
+use Larsklopstra\Nebula\Contracts\NebulaPage;
+
+class PageController
+{
+    public function index(NebulaPage $page)
+    {
+        return view('nebula::pages.index', [
+            'page' => $page,
+        ]);
+    }
+}

--- a/src/Http/Controllers/PageController.php
+++ b/src/Http/Controllers/PageController.php
@@ -2,12 +2,18 @@
 
 namespace Larsklopstra\Nebula\Http\Controllers;
 
+use Illuminate\Auth\Access\AuthorizationException;
+use Illuminate\Http\Request;
 use Larsklopstra\Nebula\Contracts\NebulaPage;
 
 class PageController
 {
-    public function index(NebulaPage $page)
+    public function index(Request $request, NebulaPage $page)
     {
+        if ($page->canSeeCallback && ! ($page->canSeeCallback)($request)) {
+            throw new AuthorizationException;
+        }
+
         return view('nebula::pages.index', [
             'page' => $page,
         ]);

--- a/src/NebulaServiceProvider.php
+++ b/src/NebulaServiceProvider.php
@@ -10,6 +10,7 @@ use Larsklopstra\Nebula\Console\Commands\InstallCommand;
 use Larsklopstra\Nebula\Console\Commands\MakeDashboardCommand;
 use Larsklopstra\Nebula\Console\Commands\MakeFieldCommand;
 use Larsklopstra\Nebula\Console\Commands\MakeFilterCommand;
+use Larsklopstra\Nebula\Console\Commands\MakePageCommand;
 use Larsklopstra\Nebula\Console\Commands\MakeResourceCommand;
 use Larsklopstra\Nebula\Console\Commands\MakeValueMetricCommand;
 
@@ -45,6 +46,7 @@ class NebulaServiceProvider extends ServiceProvider
                 MakeDashboardCommand::class,
                 MakeFilterCommand::class,
                 MakeFieldCommand::class,
+                MakePageCommand::class,
             ]);
         }
     }
@@ -130,7 +132,7 @@ class NebulaServiceProvider extends ServiceProvider
             }
 
             foreach ($pages as $page) {
-                $pageExists = Str::of($page->name())
+                $pageExists = Str::of($page->slug())
                     ->lower()
                     ->is($value);
 

--- a/src/NebulaServiceProvider.php
+++ b/src/NebulaServiceProvider.php
@@ -27,6 +27,7 @@ class NebulaServiceProvider extends ServiceProvider
         $this->resourceResolver();
         $this->itemResolver();
         $this->dashboardResolver();
+        $this->pageResolver();
 
         if ($this->app->runningInConsole()) {
             $this->publishes([
@@ -116,6 +117,29 @@ class NebulaServiceProvider extends ServiceProvider
             return $model::withoutGlobalScopes()
                 ->where((new $model)->getRouteKeyName(), $value)
                 ->firstOrFail();
+        });
+    }
+
+    public function pageResolver(): void
+    {
+        Route::bind('page', function ($value) {
+            $pages = config('nebula.pages', []);
+
+            if (empty($pages)) {
+                throw new Exception('No pages set in the nebula config.');
+            }
+
+            foreach ($pages as $page) {
+                $pageExists = Str::of($page->name())
+                    ->lower()
+                    ->is($value);
+
+                if ($pageExists) {
+                    return $page;
+                }
+            }
+
+            throw new Exception("Page {$page} not found.");
         });
     }
 }

--- a/tests/ConsoleCommandTest.php
+++ b/tests/ConsoleCommandTest.php
@@ -94,4 +94,20 @@ final class ConsoleCommandTest extends TestCase
 
         $this->artisan('nebula:value');
     }
+
+    /** @test can run php artisan nebula:page */
+    public function can_run_artisan_nebula_page()
+    {
+        $command = $this->artisan('nebula:page', ['name' => 'ExamplePage']);
+
+        $command->assertExitCode(0);
+    }
+
+    /** @test cannot run php artisan nebula:page */
+    public function cannot_run_artisan_nebula_page_without_name()
+    {
+        $this->expectException(RuntimeException::class);
+
+        $this->artisan('nebula:page');
+    }
 }


### PR DESCRIPTION
This PR enables users to build and register custom pages within the Nebula panel.

It introduces a new `php artisan nebula:page` command that will generate a new class in `app/Nebula/Pages`, as well as a view under `resources/views/nebula/pages`.

To register a new page, you follow the same pattern as the dashboards and resources, adding `new PageClass` under the `nebula.pages` configuration option.

The idea for these pages is similar to Laravel Nova's custom tools. Have a uniform API that allows developers to build third-party extensions for Nebula.

I've named them pages because using the term _Tool_ felt too similar to Nova, but I'm happy to change this.

It's also worth noting that the developer doesn't need to use the `nebula::layouts.shell` view in their pages view, since it will automatically be wrapped in it. Instead, they only need to worry about what their page will display.

The page also moves away from the `singularName()` and `pluralName()` pattern that the resources & dashboards follow because it didn't make much sense here. Instead the `NebulaPage::name()` method will be used for displaying the menu item and the page title.

For the URL slug / route binding, a new `NebulaPage::slug()` method has been introduced which will be used to match the page.

Happy to hear thoughts and ideas on this - this was the simplest implementation after all. 🤗