### PR TITLE
feature: manual register methods

### DIFF
--- a/resources/views/components/layouts/shell.blade.php
+++ b/resources/views/components/layouts/shell.blade.php
@@ -18,7 +18,7 @@
             </header>
 
             <nav x-show.transition.opacity="menuOpen" class="border-t border-gray-700">
-                @if ($dashboards = config('nebula.dashboards'))
+                @if ($dashboards = \Larsklopstra\Nebula\Nebula::availableDashboards())
                     <ul class="px-2 my-4 space-y-1">
 
                         <li>
@@ -50,7 +50,7 @@
                         </p>
                     </li>
 
-                    @foreach (config('nebula.resources') as $resource)
+                    @foreach (\Larsklopstra\Nebula\Nebula::availableResources() as $resource)
                         <li>
                             <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
                                 href="{{ route('nebula.resources.index', $resource->name()) }}">
@@ -62,7 +62,7 @@
 
                 </ul>
 
-                @if($pages = config('nebula.pages'))
+                @if($pages = \Larsklopstra\Nebula\Nebula::availablePages())
                     <ul class="px-2 my-4 space-y-1">
 
                         <li>
@@ -92,7 +92,7 @@
                 <p class="w-full text-base font-medium truncate font-display">{{ config('nebula.name') }}</p>
             </header>
 
-            @if ($dashboards = config('nebula.dashboards'))
+            @if ($dashboards = \Larsklopstra\Nebula\Nebula::availableDashboards())
                 <ul class="px-2 my-4 space-y-1">
 
                     <li>
@@ -124,7 +124,7 @@
                     </p>
                 </li>
 
-                @foreach (config('nebula.resources') as $resource)
+                @foreach (\Larsklopstra\Nebula\Nebula::availableResources() as $resource)
                     <li>
                         <a class="flex items-center h-10 px-2 text-sm font-medium text-gray-300 capitalize rounded-lg"
                             href="{{ route('nebula.resources.index', $resource->name()) }}">
@@ -136,7 +136,7 @@
 
             </ul>
 
-            @if ($pages = config('nebula.pages'))
+            @if ($pages = \Larsklopstra\Nebula\Nebula::availablePages())
                 <ul class="px-2 my-4 space-y-1">
 
                     <li>

--- a/src/Nebula.php
+++ b/src/Nebula.php
@@ -2,6 +2,10 @@
 
 namespace Larsklopstra\Nebula;
 
+use Larsklopstra\Nebula\Contracts\NebulaDashboard;
+use Larsklopstra\Nebula\Contracts\NebulaPage;
+use Larsklopstra\Nebula\Contracts\NebulaResource;
+
 class Nebula
 {
     protected static array $resources = [];
@@ -63,7 +67,7 @@ class Nebula
     public static function availableResources()
     {
         return collect(static::$resources)
-            ->map(fn ($resource) => new $resource)
+            ->map(fn ($resource) => $resource instanceof NebulaResource ? $resource : new $resource)
             ->merge(config('nebula.resources'))
             ->unique()
             ->toArray();
@@ -77,7 +81,7 @@ class Nebula
     public static function availableDashboards()
     {
         return collect(static::$dashboards)
-            ->map(fn ($dashboard) => new $dashboard)
+            ->map(fn ($dashboard) => $dashboard instanceof NebulaDashboard ? $dashboard : new $dashboard)
             ->merge(config('nebula.dashboards'))
             ->unique()
             ->toArray();
@@ -91,7 +95,7 @@ class Nebula
     public static function availablePages()
     {
         return collect(static::$pages)
-            ->map(fn ($page) => new $page)
+            ->map(fn ($page) => $page instanceof NebulaPage ? $page : new $page)
             ->merge(config('nebula.pages'))
             ->unique()
             ->toArray();

--- a/src/Nebula.php
+++ b/src/Nebula.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Larsklopstra\Nebula;
+
+class Nebula
+{
+    protected static array $resources = [];
+
+    protected static array $dashboards = [];
+
+    protected static array $pages = [];
+
+    /**
+     * Manually register resources.
+     *
+     * @param  array  $resources
+     * @return static
+     */
+    public static function resources(array $resources = [])
+    {
+        static::$resources = array_unique(
+            array_merge(static::$resources, $resources)
+        );
+
+        return new static;
+    }
+
+    /**
+     * Manually register dashboards.
+     *
+     * @param  array  $dashboards
+     * @return static
+     */
+    public static function dashboards(array $dashboards = [])
+    {
+        static::$dashboards = array_unique(
+            array_merge(static::$dashboards, $dashboards)
+        );
+
+        return new static;
+    }
+
+    /**
+     * Manually register pages.
+     *
+     * @param  array  $pages
+     * @return static
+     */
+    public static function pages(array $pages = [])
+    {
+        static::$pages = array_unique(
+            array_merge(static::$pages, $pages)
+        );
+
+        return new static;
+    }
+
+    /**
+     * Get the registered resources.
+     *
+     * @return array
+     */
+    public static function availableResources()
+    {
+        return collect(static::$resources)
+            ->map(fn ($resource) => new $resource)
+            ->merge(config('nebula.resources'))
+            ->unique()
+            ->toArray();
+    }
+
+    /**
+     * Get the registered dashboards.
+     *
+     * @return array
+     */
+    public static function availableDashboards()
+    {
+        return collect(static::$dashboards)
+            ->map(fn ($dashboard) => new $dashboard)
+            ->merge(config('nebula.dashboards'))
+            ->unique()
+            ->toArray();
+    }
+
+    /**
+     * Get the registered pages.
+     *
+     * @return array
+     */
+    public static function availablePages()
+    {
+        return collect(static::$pages)
+            ->map(fn ($page) => new $page)
+            ->merge(config('nebula.pages'))
+            ->unique()
+            ->toArray();
+    }
+}

--- a/src/NebulaServiceProvider.php
+++ b/src/NebulaServiceProvider.php
@@ -68,7 +68,7 @@ class NebulaServiceProvider extends ServiceProvider
     public function resourceResolver(): void
     {
         Route::bind('resource', function ($value) {
-            $resources = config('nebula.resources');
+            $resources = Nebula::availableResources();
 
             if (empty($resources)) {
                 throw new Exception('No resources set in the nebula config.');
@@ -91,7 +91,7 @@ class NebulaServiceProvider extends ServiceProvider
     public function dashboardResolver(): void
     {
         Route::bind('dashboard', function ($value) {
-            $dashboards = config('nebula.dashboards');
+            $dashboards = Nebula::availableDashboards();
 
             if (empty($dashboards)) {
                 throw new Exception('No dashboards set in the nebula config.');
@@ -125,7 +125,7 @@ class NebulaServiceProvider extends ServiceProvider
     public function pageResolver(): void
     {
         Route::bind('page', function ($value) {
-            $pages = config('nebula.pages', []);
+            $pages = Nebula::availablePages();
 
             if (empty($pages)) {
                 throw new Exception('No pages set in the nebula config.');

--- a/tests/RegistrationMethodsTest.php
+++ b/tests/RegistrationMethodsTest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace Larsklopstra\Nebula\Tests;
+
+class RegistrationMethodsTest extends TestCase
+{
+    //
+}


### PR DESCRIPTION
This PR adds 6 new methods to a brand new `Nebula` class in the root of the package. This class will act as the central source of truth for resources, dashboards and now pages.

`Nebula::resources()` - used to register an array of resources:

```php
Nebula::resources([
    ExampleResource::class,
]);
```

`Nebula::availableResources()` - used to retrieve the array of available / registered resources.

There are equivalent methods for dashboards and pages too. This will allow developers to manually register resources inside of a service providers `boot` method, and will also create a new place for more filtering based on permissions, etc in the future.