### PR TITLE
fix(dashboards): remove hardcoded label in favor of object method

### DIFF
--- a/resources/views/dashboards/index.blade.php
+++ b/resources/views/dashboards/index.blade.php
@@ -3,7 +3,7 @@
     <div class="mb-8 space-y-4">
 
         <h2 class="text-base font-medium font-display">
-            {{ __('Last month') }}
+            {{ $dashboard->label() }}
         </h2>
 
         <div class="grid grid-cols-12 gap-6">

--- a/src/Contracts/NebulaDashboard.php
+++ b/src/Contracts/NebulaDashboard.php
@@ -62,4 +62,14 @@ abstract class NebulaDashboard
     {
         return Str::plural($this->singularName());
     }
+
+    /**
+     * Returns the label for the dashboard.
+     *
+     * @return string
+     */
+    public function label()
+    {
+        return __('Last month');
+    }
 }


### PR DESCRIPTION
This PR adds a new `NebulaDashboard::label()` method that is used to determine the label / text shown at the top of a dashboard's page.
<img width="1146" alt="image" src="https://user-images.githubusercontent.com/41837763/95877406-fb143780-0d6b-11eb-9a65-90dc942b5599.png">
