### PR TITLE
feature(dashboards): custom views

### DIFF
--- a/resources/views/dashboards/default-metrics.blade.php
+++ b/resources/views/dashboards/default-metrics.blade.php
@@ -1,0 +1,7 @@
+<div class="grid grid-cols-12 gap-6">
+
+    @foreach ($dashboard->metrics() as $metric)
+        <x-dynamic-component :component="$metric->component()" :metric="$metric" />
+    @endforeach
+
+</div>

--- a/resources/views/dashboards/default.blade.php
+++ b/resources/views/dashboards/default.blade.php
@@ -2,10 +2,4 @@
     {{ __('Last month') }}
 </h2>
 
-<div class="grid grid-cols-12 gap-6">
-
-    @foreach ($dashboard->metrics() as $metric)
-        <x-dynamic-component :component="$metric->component()" :metric="$metric" />
-    @endforeach
-
-</div>
+{{ $dashboard->displayMetrics() }}

--- a/resources/views/dashboards/default.blade.php
+++ b/resources/views/dashboards/default.blade.php
@@ -1,0 +1,11 @@
+<h2 class="text-base font-medium font-display">
+    {{ __('Last month') }}
+</h2>
+
+<div class="grid grid-cols-12 gap-6">
+
+    @foreach ($dashboard->metrics() as $metric)
+        <x-dynamic-component :component="$metric->component()" :metric="$metric" />
+    @endforeach
+
+</div>

--- a/resources/views/dashboards/default.blade.php
+++ b/resources/views/dashboards/default.blade.php
@@ -1,5 +1,5 @@
 <h2 class="text-base font-medium font-display">
-    {{ __('Last month') }}
+    {{ $dashboard->label() }}
 </h2>
 
 {{ $dashboard->displayMetrics() }}

--- a/resources/views/dashboards/index.blade.php
+++ b/resources/views/dashboards/index.blade.php
@@ -1,19 +1,7 @@
 <x-nebula::layouts.shell :title="__(':Dashboard dashboard', ['dashboard' => $dashboard->singularName()])">
 
     <div class="mb-8 space-y-4">
-
-        <h2 class="text-base font-medium font-display">
-            {{ __('Last month') }}
-        </h2>
-
-        <div class="grid grid-cols-12 gap-6">
-
-            @foreach ($dashboard->metrics() as $metric)
-                <x-dynamic-component :component="$metric->component()" :metric="$metric" />
-            @endforeach
-
-        </div>
-
+        {{ $dashboard->display() }}
     </div>
 
 </x-nebula::layouts.shell>

--- a/src/Contracts/NebulaDashboard.php
+++ b/src/Contracts/NebulaDashboard.php
@@ -66,11 +66,23 @@ abstract class NebulaDashboard
     /**
      * Render the view for the dashboard.
      *
-     * @return mixed
+     * @return \Illuminate\View\View|string
      */
     public function display()
     {
         return app()->call([$this, 'render']);
+    }
+
+    /**
+     * Render the metrics for the dashboard.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function displayMetrics()
+    {
+        return view('nebula::dashboards.default-metrics', [
+            'dashboard' => $this,
+        ]);
     }
 
     /**

--- a/src/Contracts/NebulaDashboard.php
+++ b/src/Contracts/NebulaDashboard.php
@@ -62,4 +62,26 @@ abstract class NebulaDashboard
     {
         return Str::plural($this->singularName());
     }
+
+    /**
+     * Render the view for the dashboard.
+     *
+     * @return mixed
+     */
+    public function display()
+    {
+        return app()->call([$this, 'render']);
+    }
+
+    /**
+     * Render the contents of the dashboard.
+     *
+     * @return \Illuminate\View\View|string
+     */
+    public function render()
+    {
+        return view('nebula::dashboards.default', [
+            'dashboard' => $this,
+        ]);
+    }
 }


### PR DESCRIPTION
This PR adds a couple of new methods to the `NebulaDashboard` class:

* `NebulaDashboard::display()` - similar to `NebulaPage::display()`, is the parent method used for calling the underlying `render` method.

* `NebulaDashboard::render()` - used to change the view that a dashboard returns, allowing for custom views.

* `NebulaDashboard::displayMetrics()` - used to render the metrics, using the default view provided by Nebula.

These changes will allow developers to change the view that is used for the dashboard, greatly improving the customisation, whilst still being able to render the default metrics view.